### PR TITLE
Undefine device on read error

### DIFF
--- a/Perl/hsw12_pod.pm
+++ b/Perl/hsw12_pod.pm
@@ -643,7 +643,9 @@ sub parse_input_stream {
 		$self->{terminal_window}->see('end');
 	    } else {
 		printf STDERR "Error! Can't read from device \"%s\" (%s)\n", $self->{device}, $!;
-	    }	
+	    }
+	    #undefine device on read error
+	    $self->set_device(undef);	
 	} else {
 	    ######################
 	    # parse input string #


### PR DESCRIPTION
hsw12_pod.pm::parse_input_stream: resolves #6 (Unplugging connected
device freezes GUI)