### PR TITLE
hsw12_asm.pm: fix precompiler 'CPU' pseudo opcode detection

### DIFF
--- a/Perl/hsw12_asm.pm
+++ b/Perl/hsw12_asm.pm
@@ -363,7 +363,10 @@ Dirk Heisswolf
      -Each S5 record now shows the number of S1/2/3 records after the initial S0-record.
       (Previously the count was reset after each S5 record)
  -enhanced fill byte option in S-record generation (now alinment to phrases > 1 byte supported)     
-  
+
+=item V00.58 - Dec 14, 2020
+ -fixed precompiler detection of "CPU" pseudo-opcode
+
 =cut
 
 #################
@@ -411,7 +414,7 @@ use File::Basename;
 ###########
 # version #
 ###########
-*version = \"00.57";#"
+*version = \"00.58";#"
 
 #############################
 # default S-record settings #
@@ -3487,7 +3490,7 @@ sub precompile {
                     if ($ifdef_stack->[$#$ifdef_stack]->[0]){
 
 			#Interpret pseudo opcode CPU
-			if ($cpcode eq $psop_cpu) {
+			if (uc($opcode) eq 'CPU') {
 			    $cpu = uc($arguments);
 			}
 


### PR DESCRIPTION
Cf. #21. I think this might be what belongs in the precompiler:
```perl
#Interpret pseudo opcode CPU
if (uc($opcode) eq 'CPU') {
    $cpu = uc($arguments);
}
```

With this change, `#ifcpu` and `#ifncpu` now seem to work for a small test program:
```asm
    cpu hc11
    org $1000
#ifncpu hc11
    fcc 'ifncpu not working'
#else
    fcc 'ifncpu working'
#endif
#ifcpu hc11
    fcc 'ifcpu working'
#else
    fcc 'ifcpu not working'
#endif
```

Before:
```
??????        hc11 CODE:                  cpu hc11
001000 0F5000                             org $1000
001000 0F5000 69 66 6E 63 70 75 20 6E     fcc 'ifncpu not working'
              6F 74 20 77 6F 72 6B 69 
              6E 67                   
001012 0F5012 69 66 63 70 75 20 6E 6F     fcc 'ifcpu not working'
              74 20 77 6F 72 6B 69 6E 
              67                      
```

After:
```
??????        hc11 CODE:                  cpu hc11
001000 0F5000                             org $1000
001000 0F5000 69 66 6E 63 70 75 20 77     fcc 'ifncpu working'
              6F 72 6B 69 6E 67       
00100E 0F500E 69 66 63 70 75 20 77 6F     fcc 'ifcpu working'
              72 6B 69 6E 67          
``` 